### PR TITLE
Fix typo inside dig method

### DIFF
--- a/redfish_client/resource.py
+++ b/redfish_client/resource.py
@@ -85,7 +85,7 @@ class Resource(object):
         resource = self
         for k in keys:
             if k in resource:
-                resource = resurce._get(k)
+                resource = resource._get(k)
             else:
                 return None
         return resource


### PR DESCRIPTION
There was a typo in a file `resource.py` inside `dig` method.