### PR TITLE
Add method that allows us to poll server until it matches the expected value

### DIFF
--- a/redfish_client/exceptions.py
+++ b/redfish_client/exceptions.py
@@ -1,0 +1,29 @@
+#  Copyright 2019 XLAB d.o.o.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+
+class ClientException(Exception):
+    pass
+
+
+class TimedOutException(ClientException):
+    pass
+
+
+class BlacklistedValueException(ClientException):
+    pass
+
+
+class MissingOidException(ClientException):
+    pass


### PR DESCRIPTION
`wait_for` allows us to poll server until it matches the expected value, we can also set parameter which values we don't want to expect. Method will timeout after some specified time. 

We can wait for a value in current level of object like so:

```
root.Systems.Members[0].wait_for(['PowerState'], 'On', timeout=30)
```

or for nested key:

```
root.Systems.Members[0].wait_for(['ProcessorSummary', 'Status'], {
             "State": "Enabled",
             "Health": "OK",
             "HealthRollup": "OK"
         }, timeout=30)
```

Method would be useful in cases where response from the server is asynchronous. For example when we are executing system reset actions, we want to wait for the desired PowerState value before continuing.

\cc @miha-plesko 


