### PR TITLE
Action extensions

### DIFF
--- a/redfish_client/resource.py
+++ b/redfish_client/resource.py
@@ -155,3 +155,36 @@ class Resource(object):
     @property
     def raw(self):
         return self._content
+
+    def post(self, payload=None):
+        """
+        Perform a POST at the resource with the given payload.
+
+        Args:
+          payload: The contents of the POST payload.
+        """
+        path = self._content.get("@odata.id")
+        if not path:
+            raise MissingOidException("The resource cannot be POSTed to.")
+        return self._connector.post(path, payload=payload)
+
+    def patch(self, payload):
+        """
+        Perform a PATCH at the resource with the given payload.
+
+        Args:
+          payload: The contents of the POST payload.
+        """
+        path = self._content.get("@odata.id")
+        if not path:
+            raise MissingOidException("The resource cannot be PATCHed.")
+        return self._connector.patch(path, payload=payload)
+
+    def delete(self):
+        """
+        Perform a DELETE at the resource.
+        """
+        path = self._content.get("@odata.id")
+        if not path:
+            raise MissingOidException("The resource cannot be DELETEd.")
+        return self._connector.delete(path)

--- a/redfish_client/resource.py
+++ b/redfish_client/resource.py
@@ -111,6 +111,13 @@ class Resource(object):
                     return result
 
     def execute_action(self, action_name, payload):
+        """
+        Perform an action supported by the resource.
+
+        Args:
+          action_name: The field representing the action to perform.
+          payload: The dictionary with the action parameters.
+        """
         if "Actions" not in self._content:
             raise KeyError("Element does not have Actions attribute")
         action = self.Actions.find_object(action_name)

--- a/tests/test_resource.py
+++ b/tests/test_resource.py
@@ -17,7 +17,8 @@ from unittest import mock
 import pytest
 
 from redfish_client.connector import Connector, Response
-from redfish_client.exceptions import BlacklistedValueException, TimedOutException
+from redfish_client.exceptions import (BlacklistedValueException,
+    MissingOidException, TimedOutException)
 from redfish_client.resource import Resource
 
 
@@ -104,3 +105,48 @@ class TestWaitFor:
             }).wait_for(["PowerState"], "Off", timeout=0.1)
 
 
+class TestPost:
+    def test_post_on_resource(self):
+        connector = mock.Mock(spec=Connector)
+        Resource(connector, data={
+            "@odata.id": "/redfish/v1/EventService/Subscriptions/"
+        }).post(payload={"Destination": "http://123.10.10.234"})
+        connector.post.assert_called_once_with(
+            "/redfish/v1/EventService/Subscriptions/", payload={"Destination":
+            "http://123.10.10.234"})
+
+    def test_post_on_resource_invalid(self):
+        connector = mock.Mock(spec=Connector)
+        with pytest.raises(MissingOidException):
+            Resource(connector, data={}).post(payload={})
+
+
+class TestDelete:
+    def test_delete_a_resource(self):
+        connector = mock.Mock(spec=Connector)
+        Resource(connector, data={
+            "@odata.id": "/redfish/v1/Managers/Steampunk/Accounts/4"
+            }
+        ).delete()
+        connector.delete.assert_called_once_with(
+            "/redfish/v1/Managers/Steampunk/Accounts/4")
+
+    def test_delete_an_invalid_resource(self):
+        connector = mock.Mock(spec=Connector)
+        with pytest.raises(MissingOidException):
+            Resource(connector, data={}).delete()
+
+
+class TestPatch:
+    def test_patch_a_resource(self):
+        connector = mock.Mock(spec=Connector)
+        Resource(connector, data={
+            "@odata.id": "/redfish/v1/Systems/1"
+        }).patch(payload={"Misc": "MyValue"})
+        connector.patch.assert_called_once_with(
+            "/redfish/v1/Systems/1", payload={"Misc": "MyValue"})
+
+    def test_patch_an_invalid_resource(self):
+        connector = mock.Mock(spec=Connector)
+        with pytest.raises(MissingOidException):
+            Resource(connector, data={}).patch(payload={"Misc": "MyValue"})


### PR DESCRIPTION
I added `POST`, `PATCH` and `DELETE` methods to the resource ~and enabled the representation to be refreshed from the remote server, cleaning the cache~.
And I stuck a docstring that I wrote for my own version of `execute_action` to the appropriate method.

/cc @aljazkosir 