### PR TITLE
Connector refactor

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 pytest = "*"
 pytest-cov = "*"
+requests-mock = "*"
 
 [packages]
 redfish-client = {editable = true,path = "."}

--- a/redfish_client/__init__.py
+++ b/redfish_client/__init__.py
@@ -12,14 +12,12 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from __future__ import absolute_import, unicode_literals
-
 from redfish_client.connector import Connector
 from redfish_client.root import Root
 
 
 def connect(base_url, username, password, verify=True):
-    connector = Connector(base_url, verify=verify)
+    connector = Connector(base_url, username, password, verify=verify)
     root = Root(connector, oid="/redfish/v1")
-    root.login(username, password)
+    root.login()
     return root

--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -150,3 +150,6 @@ class Connector:
 
     def delete(self, path):
         return self._request("DELETE", path)
+
+    def reset(self, _path=None):
+        pass

--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -12,18 +12,19 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from __future__ import absolute_import, unicode_literals
-
+import base64
 import collections
 import json
 
 import requests
 
+from redfish_client.exceptions import AuthException
+
 
 Response = collections.namedtuple("Response", "status headers json raw")
 
 
-class Connector(object):
+class Connector:
     # Default headers, as required by Redfish spec
     # https://redfish.dmtf.org/schemas/DSP0266_1.5.0.html#request-headers
     DEFAULT_HEADERS = {
@@ -31,9 +32,16 @@ class Connector(object):
         "OData-Version": "4.0"
     }
 
-    def __init__(self, base_url, verify=True):
+    def __init__(self, base_url, username, password, verify=True):
         self._base_url = base_url.rstrip("/")
-        self._headers = {}
+        self._username = username
+        self._password = password
+
+        self._session_path = None
+        self._session_id = None
+
+        self._basic_path = None
+
         self._client = requests.Session()
         self._client.verify = verify
         self._client.headers = Connector.DEFAULT_HEADERS
@@ -45,6 +53,10 @@ class Connector(object):
         args = dict(json=payload) if payload else {}
         resp = self._client.request(method, self._url(path), **args)
 
+        if resp.status_code == 401:
+            self.login()
+            resp = self._client.request(method, self._url(path), **args)
+
         try:
             json_data = resp.json()
         except json.JSONDecodeError:
@@ -53,8 +65,79 @@ class Connector(object):
 
         return Response(resp.status_code, headers, json_data, resp.content)
 
-    def set_header(self, key, value):
+    def _set_header(self, key, value):
         self._client.headers[key] = value
+
+    def _unset_header(self, key):
+        if key in self._client.headers:
+            del self._client.headers[key]
+
+    def set_session_auth_data(self, path, session_id=None, token=None):
+        self._basic_logout()
+        self._basic_path = None
+
+        self._session_path = path
+        self._session_id = session_id
+        if token:
+            self._set_header("x-auth-token", token)
+
+    def set_basic_auth_data(self, path):
+        self._session_logout()
+        self._session_path = None
+
+        self._basic_path = path
+
+    @property
+    def _has_session_support(self):
+        return bool(self._session_path)
+
+    def _session_login(self):
+        resp = self._client.post(self._url(self._session_path), json=dict(
+            UserName=self._username, Password=self._password,
+        ))
+        if resp.status_code != 201:
+            raise AuthException("Cannot create session: {}".format(resp.text))
+
+        self._set_header("x-auth-token", resp.headers["x-auth-token"])
+        # We combine with `or` here because the default value of the dict.get
+        # method is eagerly evaluated, which is not what we want.
+        self._session_id = (
+            resp.headers.get("location") or resp.json()["@odata.id"]
+        )
+
+    def _session_logout(self):
+        if self._session_id:
+            self._client.delete(self._url(self._session_id))
+            self._session_id = None
+        self._unset_header("x-auth-token")
+
+    def _basic_login(self):
+        secret = "Basic {}".format(base64.b64encode(
+            "{}:{}".format(self._username, self._password).encode("ascii"),
+        ).decode("ascii"))
+        resp = self._client.get(
+            self._url(self._basic_path), headers=dict(authorization=secret),
+        )
+        if resp.status_code != 200:
+            raise AuthException("Invalid credentials")
+        self._set_header("authorization", secret)
+
+    def _basic_logout(self):
+        self._unset_header("authorization")
+
+    def login(self):
+        assert self._session_path or self._basic_path, "Use set_*_auth_data"
+
+        if self._has_session_support:
+            self._basic_logout()
+            self._session_login()
+        else:
+            self._session_logout()
+            self._basic_login()
+
+    def logout(self):
+        self._session_logout()
+        self._basic_logout()
 
     def get(self, path):
         return self._request("GET", path)

--- a/redfish_client/exceptions.py
+++ b/redfish_client/exceptions.py
@@ -27,3 +27,7 @@ class BlacklistedValueException(ClientException):
 
 class MissingOidException(ClientException):
     pass
+
+
+class AuthException(ClientException):
+    pass

--- a/redfish_client/resource.py
+++ b/redfish_client/resource.py
@@ -55,9 +55,9 @@ class Resource(object):
             url, fragment = oid, ""
 
         resp = self._connector.get(url)
-        if resp.status_code != 200:
-            raise Exception(resp.content)
-        return dict(resp.headers), self._get_fragment(resp.json(), fragment)
+        if resp.status != 200:
+            raise Exception(resp.raw)
+        return resp.headers, self._get_fragment(resp.json, fragment)
 
     def _build(self, data):
         if isinstance(data, dict):

--- a/redfish_client/root.py
+++ b/redfish_client/root.py
@@ -26,8 +26,8 @@ class Root(Resource):
         resp = self._connector.post(
             session_path, payload=dict(UserName=username, Password=password)
         )
-        self._connector.set_header("X-Auth-Token",
-                                   resp.headers["X-Auth-Token"])
+        self._connector.set_header("x-auth-token",
+                                   resp.headers["x-auth-token"])
 
     def _basic_login(self, username, password):
         self._connector.set_header("Authorization",

--- a/tests/test_caching_connector.py
+++ b/tests/test_caching_connector.py
@@ -1,0 +1,77 @@
+#  Copyright 2019 XLAB d.o.o.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from redfish_client.caching_connector import CachingConnector
+
+
+class TestGet:
+    def test_get_caching_ok(self, requests_mock):
+        requests_mock.get("https://demo.dev/data", [
+            dict(status_code=200, json=dict(hello="fish")),
+            dict(status_code=200, json=dict(solong="fish")),
+        ])
+        conn = CachingConnector("https://demo.dev", None, None)
+        assert conn.get("/data").json == dict(hello="fish")
+        assert conn.get("/data").json == dict(hello="fish")
+
+    def test_get_caching_non_ok(self, requests_mock):
+        requests_mock.get("https://demo.dev/data", [
+            dict(status_code=404, json=dict(error="bad")),
+            dict(status_code=500, json=dict(really="bad")),
+        ])
+        conn = CachingConnector("https://demo.dev", None, None)
+        assert conn.get("/data").json == dict(error="bad")
+        assert conn.get("/data").json == dict(really="bad")
+
+
+class TestReset:
+    @staticmethod
+    def mock_paths(mock):
+        mock.get("https://demo.dev/1", [
+            dict(status_code=200, json=dict(hello="fish")),
+            dict(status_code=200, json=dict(hello="bear")),
+        ])
+        mock.get("https://demo.dev/2", [
+            dict(status_code=200, json=dict(solong="fish")),
+            dict(status_code=200, json=dict(solong="bear")),
+        ])
+
+    def test_reset_all(self, requests_mock):
+        self.mock_paths(requests_mock)
+        conn = CachingConnector("https://demo.dev", "user", "pass")
+        assert conn.get("/1").json == dict(hello="fish")
+        assert conn.get("/2").json == dict(solong="fish")
+        conn.reset()
+        assert conn.get("/1").json == dict(hello="bear")
+        assert conn.get("/2").json == dict(solong="bear")
+
+    def test_reset_with_path(self, requests_mock):
+        self.mock_paths(requests_mock)
+        conn = CachingConnector("https://demo.dev", "user", "pass")
+        assert conn.get("/1").json == dict(hello="fish")
+        assert conn.get("/2").json == dict(solong="fish")
+        conn.reset("/2")
+        assert conn.get("/1").json == dict(hello="fish")
+        assert conn.get("/2").json == dict(solong="bear")
+
+    def test_reset_with_non_cached_path(self, requests_mock):
+        self.mock_paths(requests_mock)
+        conn = CachingConnector("https://demo.dev", "user", "pass")
+        assert conn.get("/1").json == dict(hello="fish")
+        assert conn.get("/2").json == dict(solong="fish")
+        conn.reset("/3")
+        assert conn.get("/1").json == dict(hello="fish")
+        assert conn.get("/2").json == dict(solong="fish")

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,0 +1,216 @@
+#  Copyright 2019 XLAB d.o.o.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import pytest
+
+from redfish_client.connector import Connector
+from redfish_client.exceptions import AuthException
+
+
+class TestLogin:
+    def test_basic_login(self, requests_mock):
+        requests_mock.get(
+            "https://demo.dev/test_auth", status_code=200,
+            request_headers=dict(Authorization="Basic dXNlcjpwYXNz"),
+        )
+        conn = Connector("https://demo.dev", "user", "pass")
+        conn.set_basic_auth_data("/test_auth")
+        conn.login()
+
+    def test_basic_login_invalid_credentials(self, requests_mock):
+        requests_mock.get("https://demo.dev/test_auth", status_code=401)
+        conn = Connector("https://demo.dev", "user", "notpass")
+        conn.set_basic_auth_data("/test_auth")
+        with pytest.raises(AuthException):
+            conn.login()
+
+    def test_session_login_id_in_location_header(self, requests_mock):
+        def matcher(req):
+            return (
+                req.json()["UserName"] == "user" and
+                req.json()["Password"] == "pass"
+            )
+
+        requests_mock.post(
+            "https://demo.dev/sessions", additional_matcher=matcher,
+            status_code=201,
+            headers={"X-Auth-Token": "abc", "Location": "/sessions/1"},
+        )
+        conn = Connector("https://demo.dev", "user", "pass")
+        conn.set_session_auth_data("/sessions")
+        conn.login()
+
+    def test_session_login_id_in_body(self, requests_mock):
+        def matcher(req):
+            return (
+                req.json()["UserName"] == "user1" and
+                req.json()["Password"] == "pass1"
+            )
+
+        requests_mock.post(
+            "https://demo.dev/sessions", additional_matcher=matcher,
+            status_code=201, headers={"X-Auth-Token": "abc"},
+            json={"@odata.id": "/sessions/1"},
+        )
+        conn = Connector("https://demo.dev", "user1", "pass1")
+        conn.set_session_auth_data("/sessions")
+        conn.login()
+
+    def test_session_login_invalid_credentials(self, requests_mock):
+        requests_mock.post(
+            "https://demo.dev/sessions", status_code=400, text="Invalid",
+        )
+        conn = Connector("https://demo.dev", "user1", "pass1")
+        conn.set_session_auth_data("/sessions")
+        with pytest.raises(AuthException):
+            conn.login()
+
+
+class TestLogout:
+    def test_basic_logout(self, requests_mock):
+        conn = Connector("https://demo.dev", "user", "pass")
+        conn.set_basic_auth_data("/test_auth")
+        conn.logout()
+
+    def test_session_logout(self, requests_mock):
+        requests_mock.delete(
+            "https://demo.dev/sessions/1", status_code=204,
+            request_headers={"X-Auth-Token": "abc"},
+        )
+        conn = Connector("https://demo.dev", "user1", "pass1")
+        conn.set_session_auth_data("/sessions", "/sessions/1", "abc")
+        conn.logout()
+
+    def test_session_logout_expired_session(self, requests_mock):
+        requests_mock.delete("https://demo.dev/sessions/1", status_code=401)
+        conn = Connector("https://demo.dev", "user", "pass")
+        conn.set_session_auth_data("/sessions", "/sessions/1", "invalid")
+        conn.logout()
+
+    def test_session_logout_no_session(self, requests_mock):
+        conn = Connector("https://demo.dev", "user", "pass")
+        conn.set_session_auth_data("/sessions")
+        conn.logout()
+
+
+class TestGet:
+    def test_get_no_auth(self, requests_mock):
+        requests_mock.get(
+            "https://demo.dev/data", status_code=200, json=dict(hello="fish"),
+        )
+        conn = Connector("https://demo.dev", "user", "pass")
+        r = conn.get("/data")
+        assert r.status == 200
+        assert r.json == dict(hello="fish")
+
+    def test_get_non_json_body(self, requests_mock):
+        requests_mock.get("https://demo.dev/data", status_code=200)
+        conn = Connector("https://demo.dev", "user", "pass")
+        r = conn.get("/data")
+        assert r.status == 200
+        assert r.json is None
+
+    def test_get_non_200(self, requests_mock):
+        requests_mock.get(
+            "https://demo.dev/data", status_code=404, json=dict(error="bad"),
+        )
+        conn = Connector("https://demo.dev", "user", "pass")
+        r = conn.get("/data")
+        assert r.status == 404
+        assert r.json == dict(error="bad")
+
+    def test_get_basic_relogin(self, requests_mock):
+        # Define more specific mock aafter less specific ones, since they are
+        # matched in bottom-up order.
+        requests_mock.get("https://demo.dev/data", status_code=401)
+        requests_mock.get(
+            "https://demo.dev/test", status_code=200,
+            request_headers=dict(Authorization="Basic dXNlcjpwYXNz"),
+        )
+        requests_mock.get(
+            "https://demo.dev/data", status_code=200,
+            request_headers=dict(Authorization="Basic dXNlcjpwYXNz"),
+        )
+        conn = Connector("https://demo.dev", "user", "pass")
+        conn.set_basic_auth_data("/test")
+        r = conn.get("/data")
+        assert r.status == 200
+        assert r.json is None
+
+    def test_get_session_relogin(self, requests_mock):
+        requests_mock.get("https://demo.dev/data", [
+            dict(status_code=401), dict(status_code=200),
+        ])
+        requests_mock.post(
+            "https://demo.dev/sessions", status_code=201,
+            headers={"X-Auth-Token": "123", "Location": "/sessions/3"},
+        )
+        conn = Connector("https://demo.dev", "user", "pass")
+        conn.set_session_auth_data("/sessions")
+        r = conn.get("/data")
+        assert r.status == 200
+        assert r.json is None
+
+    def test_get_use_existing_session(self, requests_mock):
+        requests_mock.get(
+            "https://demo.dev/data", status_code=200,
+            request_headers={"X-Auth-Token": "123"},
+        )
+        conn = Connector("https://demo.dev", "user", "pass")
+        conn.set_session_auth_data("/sessions", "/sessions/1", "123")
+        r = conn.get("/data")
+        assert r.status == 200
+        assert r.json is None
+
+
+class TestPost:
+    def test_post_no_payload(self, requests_mock):
+        requests_mock.post("https://demo.dev/post", status_code=200)
+        conn = Connector("https://demo.dev", None, None)
+        status, *_ = conn.post("/post")
+        assert status == 200
+
+    def test_post_no_payload(self, requests_mock):
+        requests_mock.post(
+            "https://demo.dev/post", status_code=200,
+            additional_matcher=lambda r: r.json()["post"] == "payload",
+        )
+        conn = Connector("https://demo.dev", None, None)
+        status, *_ = conn.post("/post", dict(post="payload"))
+        assert status == 200
+
+
+class TestPatch:
+    def test_patch_no_payload(self, requests_mock):
+        requests_mock.patch("https://demo.dev/patch", status_code=200)
+        conn = Connector("https://demo.dev", None, None)
+        status, *_ = conn.patch("/patch")
+        assert status == 200
+
+    def test_patch_no_payload(self, requests_mock):
+        requests_mock.patch(
+            "https://demo.dev/patch", status_code=200,
+            additional_matcher=lambda r: r.json()["patch"] == "payload",
+        )
+        conn = Connector("https://demo.dev", None, None)
+        status, *_ = conn.patch("/patch", dict(patch="payload"))
+        assert status == 200
+
+
+class TestDelete:
+    def test_delete(self, requests_mock):
+        requests_mock.delete("https://demo.dev/delete", status_code=204)
+        conn = Connector("https://demo.dev", None, None)
+        status, *_ = conn.delete("/delete")
+        assert status == 204

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -173,6 +173,24 @@ class TestGet:
         assert r.status == 200
         assert r.json is None
 
+    def test_get_caching_ok(self, requests_mock):
+        requests_mock.get("https://demo.dev/data", [
+            dict(status_code=200, json=dict(hello="fish")),
+            dict(status_code=200, json=dict(solong="fish")),
+        ])
+        conn = Connector("https://demo.dev", None, None)
+        assert conn.get("/data").json == dict(hello="fish")
+        assert conn.get("/data").json == dict(solong="fish")
+
+    def test_get_caching_non_ok(self, requests_mock):
+        requests_mock.get("https://demo.dev/data", [
+            dict(status_code=404, json=dict(error="bad")),
+            dict(status_code=500, json=dict(really="bad")),
+        ])
+        conn = Connector("https://demo.dev", None, None)
+        assert conn.get("/data").json == dict(error="bad")
+        assert conn.get("/data").json == dict(really="bad")
+
 
 class TestPost:
     def test_post_no_payload(self, requests_mock):
@@ -214,3 +232,34 @@ class TestDelete:
         conn = Connector("https://demo.dev", None, None)
         status, *_ = conn.delete("/delete")
         assert status == 204
+
+
+class TestReset:
+    @staticmethod
+    def mock_paths(mock):
+        mock.get("https://demo.dev/1", [
+            dict(status_code=200, json=dict(hello="fish")),
+            dict(status_code=200, json=dict(hello="bear")),
+        ])
+        mock.get("https://demo.dev/2", [
+            dict(status_code=200, json=dict(solong="fish")),
+            dict(status_code=200, json=dict(solong="bear")),
+        ])
+
+    def test_reset_all(self, requests_mock):
+        self.mock_paths(requests_mock)
+        conn = Connector("https://demo.dev", "user", "pass")
+        assert conn.get("/1").json == dict(hello="fish")
+        assert conn.get("/2").json == dict(solong="fish")
+        conn.reset()
+        assert conn.get("/1").json == dict(hello="bear")
+        assert conn.get("/2").json == dict(solong="bear")
+
+    def test_reset_with_path(self, requests_mock):
+        self.mock_paths(requests_mock)
+        conn = Connector("https://demo.dev", "user", "pass")
+        assert conn.get("/1").json == dict(hello="fish")
+        assert conn.get("/2").json == dict(solong="fish")
+        conn.reset("/2")
+        assert conn.get("/1").json == dict(hello="bear")
+        assert conn.get("/2").json == dict(solong="bear")


### PR DESCRIPTION
As the name of the pull request already suggests, this pull request is mainly about moving things from the resource abstraction layer into connector one.

The refactoring started with us abstracting away the connector's response structure. Previously, we leaked the underlying `Response` class from the `requests` library, leaving the burden of handling non-JSON responses to the resource layer. Since the resource layer was the only consumer of the connector's public API, this worked out OK for the time being. But now we have use cases in some other pieces of our software that would use connector class in isolation (without the resource abstraction), and providing a uniform API got a bit more urgent.

Next, we moved the authentication mechanism into the connector class. This move makes it possible to use our connector class in isolation without having to resort to manually setting the headers on the connector when dealing with authentication/authorization. As a side effect, we also gained an automatic session refresh, making even our resource layer a bit nicer to use.

The last thing we did is move the caching from the resource class into the connector class. This move dramatically reduces the efficiency of the caching mechanism, since all the resources that we obtain from the root resource share the same connector instance and consequently also the same cache. As a bonus, we can now select whether we would like to use caching when we create a new root resource instance.

/cc @matejart 