### PR TITLE
Hook up unit tests to the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,10 @@ jobs:
   build:
     docker:
       - image: circleci/python:3.5.7
+        environment:
+          PIPENV_VENV_IN_PROJECT: true
     steps:
       - checkout
-      - run: echo dummy
+      - run: sudo pip install pipenv
+      - run: make init
+      - run: make test

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 .eggs
 redfish_client.egg-info
 *.pyc
+.venv
+.coverage
+htmlcov
+dist

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+init:
+	pipenv install -d
+
+test:
+	pipenv run pytest tests
+
+coverage:
+	pipenv run pytest --cov=redfish_client --cov-report=html tests
+	xdg-open htmlcov/index.html
+
+publish:
+	python3 setup.py sdist bdist_wheel
+	python3 -m twine upload dist/*

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,11 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+pytest = "*"
+pytest-cov = "*"
+
+[packages]
+redfish-client = {editable = true,path = "."}

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,4 @@ import setuptools
 setuptools.setup(
     setup_requires=["pbr>=3.0.0"],
     pbr=True,
-    tests_require=['pytest']
 )


### PR DESCRIPTION
This pull request aims to add a fully working CircleCI integration.

To achieve that, we first added pipenv configuration that allows us to prepare the environment with ease. 

Next, we wrapped the most commonly used commands into a simple Makefile to reduce the cognitive load when performing chores.

Lastly, we updated the CircleCI configuration file that now actually runs the test suite.