### PR TITLE
Fix a bug with shared headers

### DIFF
--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -44,7 +44,7 @@ class Connector:
 
         self._client = requests.Session()
         self._client.verify = verify
-        self._client.headers = Connector.DEFAULT_HEADERS
+        self._client.headers = Connector.DEFAULT_HEADERS.copy()
 
     def _url(self, path):
         return self._base_url + path

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -18,6 +18,14 @@ from redfish_client.connector import Connector
 from redfish_client.exceptions import AuthException
 
 
+class TestInit:
+    def test_header_copy(self):
+        c1 = Connector("", "", "")
+        c1._set_header("a", "b")
+        c2 = Connector("", "", "")
+        assert c1._client.headers != c2._client.headers
+
+
 class TestLogin:
     def test_basic_login(self, requests_mock):
         requests_mock.get(


### PR DESCRIPTION
Our connector constructor was missing a copy call when we initialized default headers, which caused all instances of the Connector class to share the same set of headers.

This commit fixes that error and adds a test to prevent it from creeping back in the future.