### PR TITLE
Expose session authentication data

### DIFF
--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -81,6 +81,14 @@ class Connector:
         if token:
             self._set_header("x-auth-token", token)
 
+    @property
+    def session_auth_data(self):
+        return (
+            self._session_path,
+            self._session_id,
+            self._client.headers.get("x-auth-token"),
+        )
+
     def set_basic_auth_data(self, path):
         self._session_logout()
         self._session_path = None

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -77,6 +77,32 @@ class TestLogin:
             conn.login()
 
 
+class TestSessionAuthData:
+    def test_no_data(self):
+        conn = Connector("", "", "")
+        assert (None, None, None) == conn.session_auth_data
+
+    def test_no_active_session(self):
+        conn = Connector("", "", "")
+        conn.set_session_auth_data("/sessions")
+        assert ("/sessions", None, None) == conn.session_auth_data
+
+    def test_active_session(self, requests_mock):
+        requests_mock.post(
+            "http://demo.site/sessions", status_code=201,
+            headers={"x-auth-token": "xyz", "Location": "/sessions/1"},
+        )
+        conn = Connector("http://demo.site", "", "")
+        conn.set_session_auth_data("/sessions")
+        conn.login()
+        assert ("/sessions", "/sessions/1", "xyz") == conn.session_auth_data
+
+    def test_user_supplied_session_data(self):
+        conn = Connector("", "", "")
+        conn.set_session_auth_data("/sessions", "/sessions/2", "dfg")
+        assert ("/sessions", "/sessions/2", "dfg") == conn.session_auth_data
+
+
 class TestLogout:
     def test_basic_logout(self, requests_mock):
         conn = Connector("https://demo.dev", "user", "pass")


### PR DESCRIPTION
Since Redfish sessions are relatively long-lived, we can substantially reduce the load on the Redfish API by reusing the same session and associated authentication token. But to be able to reuse authentication data, we need some way of accessing it.

This commit adds a property to the connector objects that contains currently active set of authentication data. This data can be then stored somewhere and reused when authenticating new connector.