### PR TITLE
Remove x-auth-token header before re-login

### DIFF
--- a/redfish_client/connector.py
+++ b/redfish_client/connector.py
@@ -58,6 +58,7 @@ class Connector:
                 "Endpoint at {} is not accessible".format(self._base_url))
 
         if resp.status_code == 401:
+            self._unset_header("x-auth-token")
             self.login()
             resp = self._client.request(method, self._url(path), **args)
 


### PR DESCRIPTION
The connector part of the Redfish client library has the capability to retry the request if the Redfish service that the client is talking to returns back status 401. Before the retry, connector tries to login in
order to refresh the authentication token.

It turns out that on older Dell systems (13G), sending an invalid or expired token in the x-auth-token header when creating new session also returns 401, which causes the client to back out and abort the current operation.

The updated code simply removes the x-auth-token header before trying to create a new session.